### PR TITLE
Fixed the parsing of null JSON responses decoding of key-value pairs.

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -271,7 +271,8 @@ pub enum AbciMode {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct PrivValidatorConfig {
-    /// Path to the JSON file containing the private key to use as a validator in the consensus protocol
+    /// Path to the JSON file containing the private key to use as a validator in the consensus
+    /// protocol
     pub key_file: PathBuf,
     /// Path to the JSON file containing the last sign state of a validator
     pub state_file: PathBuf,
@@ -284,7 +285,8 @@ pub struct PrivValidatorConfig {
     )]
     pub laddr: Option<net::Address>,
     /// Client certificate generated while creating needed files for secure connection.
-    /// If a remote validator address is provided but no certificate, the connection will be insecure
+    /// If a remote validator address is provided but no certificate, the connection will be
+    /// insecure
     pub client_certificate_file: Option<PathBuf>,
     /// Path to the JSON file containing the private key to use as a validator in the consensus
     /// protocol

--- a/proto/src/prost/tendermint.types.rs
+++ b/proto/src/prost/tendermint.types.rs
@@ -262,6 +262,7 @@ pub struct VoteExtension {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VoteExtensionToSign {
     #[prost(bytes="vec", tag="1")]
+    #[serde(with = "crate::serializers::nullable")]
     pub app_data_to_sign: ::prost::alloc::vec::Vec<u8>,
 }
 /// Commit contains the evidence that a block was committed by a set of validators.

--- a/tendermint/src/abci/tag.rs
+++ b/tendermint/src/abci/tag.rs
@@ -21,7 +21,6 @@ pub struct Tag {
 pub struct Key(
     #[serde(
         serialize_with = "base64string::serialize",
-        deserialize_with = "base64string::deserialize_to_string"
     )]
     String,
 );
@@ -51,7 +50,6 @@ impl fmt::Display for Key {
 pub struct Value(
     #[serde(
         serialize_with = "base64string::serialize",
-        deserialize_with = "base64string::deserialize_to_string"
     )]
     String,
 );

--- a/tendermint/src/abci/tag.rs
+++ b/tendermint/src/abci/tag.rs
@@ -18,12 +18,7 @@ pub struct Tag {
 
 /// Tag keys
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct Key(
-    #[serde(
-        serialize_with = "base64string::serialize",
-    )]
-    String,
-);
+pub struct Key(#[serde(serialize_with = "base64string::serialize")] String);
 
 impl AsRef<str> for Key {
     fn as_ref(&self) -> &str {
@@ -47,12 +42,7 @@ impl fmt::Display for Key {
 
 /// Tag values
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct Value(
-    #[serde(
-        serialize_with = "base64string::serialize",
-    )]
-    String,
-);
+pub struct Value(#[serde(serialize_with = "base64string::serialize")] String);
 
 impl AsRef<str> for Value {
     fn as_ref(&self) -> &str {


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

A workaround to enable this client to deserialize ABCI++ server messages. Specific changes:
* Allow ABCI++ client to receive `null` values in the `app_data_to_sign` field.
* Removal of base 64 decoding of the `Key`-`Value` pairs that comprise response `Tag`s.

There's a high likelihood that omission of base 64 encoding on the server's part is accidental and hence these changes to the deserializer are reversed.
