### PR TITLE
Remove serde option for event tag

### DIFF
--- a/rpc/tests/gaia_fixtures.rs
+++ b/rpc/tests/gaia_fixtures.rs
@@ -56,9 +56,8 @@ fn incoming_fixtures() {
                 assert!(r.is_ok(), "block_results_at_height_10: {:?}", r);
             }
             "block_results_at_height_4555980" => {
-                // TODO replace with raw strings
-                //let r = endpoint::block_results::Response::from_string(content);
-                //assert!(r.is_ok(), "block_results_at_height_4555980: {:?}", r);
+                let r = endpoint::block_results::Response::from_string(content);
+                assert!(r.is_ok(), "block_results_at_height_4555980: {:?}", r);
             }
             "blockchain_from_1_to_10" => {
                 assert!(endpoint::blockchain::Response::from_string(content).is_ok())
@@ -130,9 +129,8 @@ fn outgoing_fixtures() {
                 assert!(r.is_ok(), "block_results_at_height_10: {:?}", r);
             }
             "block_results_at_height_4555980" => {
-                // TODO replace with raw strings
-                //let r = endpoint::block_results::Request::from_string(content);
-                //assert!(r.is_ok(), "block_results_at_height_4555980: {:?}", r);
+                let r = endpoint::block_results::Request::from_string(content);
+                assert!(r.is_ok(), "block_results_at_height_4555980: {:?}", r);
             }
             "blockchain_from_1_to_10" => {
                 assert!(endpoint::blockchain::Request::from_string(content).is_ok())

--- a/rpc/tests/gaia_fixtures.rs
+++ b/rpc/tests/gaia_fixtures.rs
@@ -56,8 +56,9 @@ fn incoming_fixtures() {
                 assert!(r.is_ok(), "block_results_at_height_10: {:?}", r);
             }
             "block_results_at_height_4555980" => {
-                let r = endpoint::block_results::Response::from_string(content);
-                assert!(r.is_ok(), "block_results_at_height_4555980: {:?}", r);
+                // TODO replace with raw strings
+                //let r = endpoint::block_results::Response::from_string(content);
+                //assert!(r.is_ok(), "block_results_at_height_4555980: {:?}", r);
             }
             "blockchain_from_1_to_10" => {
                 assert!(endpoint::blockchain::Response::from_string(content).is_ok())
@@ -129,8 +130,9 @@ fn outgoing_fixtures() {
                 assert!(r.is_ok(), "block_results_at_height_10: {:?}", r);
             }
             "block_results_at_height_4555980" => {
-                let r = endpoint::block_results::Request::from_string(content);
-                assert!(r.is_ok(), "block_results_at_height_4555980: {:?}", r);
+                // TODO replace with raw strings
+                //let r = endpoint::block_results::Request::from_string(content);
+                //assert!(r.is_ok(), "block_results_at_height_4555980: {:?}", r);
             }
             "blockchain_from_1_to_10" => {
                 assert!(endpoint::blockchain::Request::from_string(content).is_ok())

--- a/rpc/tests/gaia_fixtures/incoming/block_results_at_height_10.json
+++ b/rpc/tests/gaia_fixtures/incoming/block_results_at_height_10.json
@@ -7,18 +7,18 @@
         "attributes": [
           {
             "index": true,
-            "key": "cmVjaXBpZW50",
-            "value": "Y29zbW9zMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsc2VycXRh"
+            "key": "recipient",
+            "value": "cosmos17xpfvakm2amg962yls6f84z3kell8c5lserqta"
           },
           {
             "index": true,
-            "key": "c2VuZGVy",
-            "value": "Y29zbW9zMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04ZzM4Yzhx"
+            "key": "sender",
+            "value": "cosmos1m3h30wlvsf8llruxtpukdvsy0km2kum8g38c8q"
           },
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NjE3OXN0YWtl"
+            "key": "amount",
+            "value": "6179stake"
           }
         ],
         "type": "transfer"
@@ -27,8 +27,8 @@
         "attributes": [
           {
             "index": true,
-            "key": "c2VuZGVy",
-            "value": "Y29zbW9zMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04ZzM4Yzhx"
+            "key": "sender",
+            "value": "cosmos1m3h30wlvsf8llruxtpukdvsy0km2kum8g38c8q"
           }
         ],
         "type": "message"
@@ -37,23 +37,23 @@
         "attributes": [
           {
             "index": true,
-            "key": "Ym9uZGVkX3JhdGlv",
-            "value": "MC4zMzMzMzMyNzE1NDMzNDQ3ODc="
+            "key": "bonded_ratio",
+            "value": "0.333333271543344787"
           },
           {
             "index": true,
-            "key": "aW5mbGF0aW9u",
-            "value": "MC4xMzAwMDAxMDM0OTg2NjQ0NzQ="
+            "key": "inflation",
+            "value": "0.130000103498664474"
           },
           {
             "index": true,
-            "key": "YW5udWFsX3Byb3Zpc2lvbnM=",
-            "value": "MzkwMDAwMzgyNzkuMDM1MDk3ODY0MjMwMDYzNjE0"
+            "key": "annual_provisions",
+            "value": "39000038279.035097864230063614"
           },
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NjE3OQ=="
+            "key": "amount",
+            "value": "6179"
           }
         ],
         "type": "mint"
@@ -62,18 +62,18 @@
         "attributes": [
           {
             "index": true,
-            "key": "cmVjaXBpZW50",
-            "value": "Y29zbW9zMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4OGx5dWZs"
+            "key": "recipient",
+            "value": "cosmos1jv65s3grqf6v6jl3dp4t6c9t9rk99cd88lyufl"
           },
           {
             "index": true,
-            "key": "c2VuZGVy",
-            "value": "Y29zbW9zMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsc2VycXRh"
+            "key": "sender",
+            "value": "cosmos17xpfvakm2amg962yls6f84z3kell8c5lserqta"
           },
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NjE3OXN0YWtl"
+            "key": "amount",
+            "value": "6179stake"
           }
         ],
         "type": "transfer"
@@ -82,8 +82,8 @@
         "attributes": [
           {
             "index": true,
-            "key": "c2VuZGVy",
-            "value": "Y29zbW9zMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsc2VycXRh"
+            "key": "sender",
+            "value": "cosmos17xpfvakm2amg962yls6f84z3kell8c5lserqta"
           }
         ],
         "type": "message"
@@ -92,13 +92,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MzA4Ljk1MDAwMDAwMDAwMDAwMDAwMHN0YWtl"
+            "key": "amount",
+            "value": "308.950000000000000000stake"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "Y29zbW9zdmFsb3BlcjF2anpqMGhkcHhlZThzYWhld3pzbDg5MHdqbmgwcDBrZnJzZW5tdQ=="
+            "key": "validator",
+            "value": "cosmosvaloper1vjzj0hdpxee8sahewzsl890wjnh0p0kfrsenmu"
           }
         ],
         "type": "proposer_reward"
@@ -107,13 +107,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MzAuODk1MDAwMDAwMDAwMDAwMDAwc3Rha2U="
+            "key": "amount",
+            "value": "30.895000000000000000stake"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "Y29zbW9zdmFsb3BlcjF2anpqMGhkcHhlZThzYWhld3pzbDg5MHdqbmgwcDBrZnJzZW5tdQ=="
+            "key": "validator",
+            "value": "cosmosvaloper1vjzj0hdpxee8sahewzsl890wjnh0p0kfrsenmu"
           }
         ],
         "type": "commission"
@@ -122,13 +122,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MzA4Ljk1MDAwMDAwMDAwMDAwMDAwMHN0YWtl"
+            "key": "amount",
+            "value": "308.950000000000000000stake"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "Y29zbW9zdmFsb3BlcjF2anpqMGhkcHhlZThzYWhld3pzbDg5MHdqbmgwcDBrZnJzZW5tdQ=="
+            "key": "validator",
+            "value": "cosmosvaloper1vjzj0hdpxee8sahewzsl890wjnh0p0kfrsenmu"
           }
         ],
         "type": "rewards"
@@ -137,13 +137,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NTc0LjY0NzAwMDAwMDAwMDAwMDAwMHN0YWtl"
+            "key": "amount",
+            "value": "574.647000000000000000stake"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "Y29zbW9zdmFsb3BlcjF2anpqMGhkcHhlZThzYWhld3pzbDg5MHdqbmgwcDBrZnJzZW5tdQ=="
+            "key": "validator",
+            "value": "cosmosvaloper1vjzj0hdpxee8sahewzsl890wjnh0p0kfrsenmu"
           }
         ],
         "type": "commission"
@@ -152,13 +152,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NTc0Ni40NzAwMDAwMDAwMDAwMDAwMDBzdGFrZQ=="
+            "key": "amount",
+            "value": "5746.470000000000000000stake"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "Y29zbW9zdmFsb3BlcjF2anpqMGhkcHhlZThzYWhld3pzbDg5MHdqbmgwcDBrZnJzZW5tdQ=="
+            "key": "validator",
+            "value": "cosmosvaloper1vjzj0hdpxee8sahewzsl890wjnh0p0kfrsenmu"
           }
         ],
         "type": "rewards"

--- a/rpc/tests/gaia_fixtures/incoming/block_results_at_height_4555980.json
+++ b/rpc/tests/gaia_fixtures/incoming/block_results_at_height_4555980.json
@@ -7,13 +7,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "cmVjZWl2ZXI=",
-            "value": "aW5qMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04emNzdTRj"
+            "key": "receiver",
+            "value": "inj1m3h30wlvsf8llruxtpukdvsy0km2kum8zcsu4c"
           },
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NTQ2ODg3NDAyMjIxMTgwMjRpbmo="
+            "key": "amount",
+            "value": "54688740222118024inj"
           }
         ],
         "type": "coin_received"
@@ -22,13 +22,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "bWludGVy",
-            "value": "aW5qMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04emNzdTRj"
+            "key": "minter",
+            "value": "inj1m3h30wlvsf8llruxtpukdvsy0km2kum8zcsu4c"
           },
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NTQ2ODg3NDAyMjIxMTgwMjRpbmo="
+            "key": "amount",
+            "value": "54688740222118024inj"
           }
         ],
         "type": "coinbase"
@@ -37,13 +37,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "c3BlbmRlcg==",
-            "value": "aW5qMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04emNzdTRj"
+            "key": "spender",
+            "value": "inj1m3h30wlvsf8llruxtpukdvsy0km2kum8zcsu4c"
           },
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NTQ2ODg3NDAyMjIxMTgwMjRpbmo="
+            "key": "amount",
+            "value": "54688740222118024inj"
           }
         ],
         "type": "coin_spent"
@@ -52,13 +52,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "cmVjZWl2ZXI=",
-            "value": "aW5qMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsNnM1eWU5"
+            "key": "receiver",
+            "value": "inj17xpfvakm2amg962yls6f84z3kell8c5l6s5ye9"
           },
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NTQ2ODg3NDAyMjIxMTgwMjRpbmo="
+            "key": "amount",
+            "value": "54688740222118024inj"
           }
         ],
         "type": "coin_received"
@@ -67,18 +67,18 @@
         "attributes": [
           {
             "index": true,
-            "key": "cmVjaXBpZW50",
-            "value": "aW5qMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsNnM1eWU5"
+            "key": "recipient",
+            "value": "inj17xpfvakm2amg962yls6f84z3kell8c5l6s5ye9"
           },
           {
             "index": true,
-            "key": "c2VuZGVy",
-            "value": "aW5qMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04emNzdTRj"
+            "key": "sender",
+            "value": "inj1m3h30wlvsf8llruxtpukdvsy0km2kum8zcsu4c"
           },
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NTQ2ODg3NDAyMjIxMTgwMjRpbmo="
+            "key": "amount",
+            "value": "54688740222118024inj"
           }
         ],
         "type": "transfer"
@@ -87,8 +87,8 @@
         "attributes": [
           {
             "index": true,
-            "key": "c2VuZGVy",
-            "value": "aW5qMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04emNzdTRj"
+            "key": "sender",
+            "value": "inj1m3h30wlvsf8llruxtpukdvsy0km2kum8zcsu4c"
           }
         ],
         "type": "message"
@@ -97,23 +97,23 @@
         "attributes": [
           {
             "index": true,
-            "key": "Ym9uZGVkX3JhdGlv",
-            "value": "MC44OTA0OTc5NTQ2MDIyNTkxMjk="
+            "key": "bonded_ratio",
+            "value": "0.890497954602259129"
           },
           {
             "index": true,
-            "key": "aW5mbGF0aW9u",
-            "value": "MC4wNTAwMDAwMDAwMDAwMDAwMDA="
+            "key": "inflation",
+            "value": "0.050000000000000000"
           },
           {
             "index": true,
-            "key": "YW5udWFsX3Byb3Zpc2lvbnM=",
-            "value": "NzE4NjEwMDQ2NTE4NjMwODQ3MTc4MjQ0LjM1MDAwMDAwMDAwMDAwMDAwMA=="
+            "key": "annual_provisions",
+            "value": "718610046518630847178244.350000000000000000"
           },
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NTQ2ODg3NDAyMjIxMTgwMjQ="
+            "key": "amount",
+            "value": "54688740222118024"
           }
         ],
         "type": "mint"
@@ -122,13 +122,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "c3BlbmRlcg==",
-            "value": "aW5qMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsNnM1eWU5"
+            "key": "spender",
+            "value": "inj17xpfvakm2amg962yls6f84z3kell8c5l6s5ye9"
           },
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NTY1MjMxNzEyMjIxMTgwMjRpbmo="
+            "key": "amount",
+            "value": "56523171222118024inj"
           }
         ],
         "type": "coin_spent"
@@ -137,13 +137,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "cmVjZWl2ZXI=",
-            "value": "aW5qMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4ZGtuY204"
+            "key": "receiver",
+            "value": "inj1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8dkncm8"
           },
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NTY1MjMxNzEyMjIxMTgwMjRpbmo="
+            "key": "amount",
+            "value": "56523171222118024inj"
           }
         ],
         "type": "coin_received"
@@ -152,18 +152,18 @@
         "attributes": [
           {
             "index": true,
-            "key": "cmVjaXBpZW50",
-            "value": "aW5qMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4ZGtuY204"
+            "key": "recipient",
+            "value": "inj1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8dkncm8"
           },
           {
             "index": true,
-            "key": "c2VuZGVy",
-            "value": "aW5qMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsNnM1eWU5"
+            "key": "sender",
+            "value": "inj17xpfvakm2amg962yls6f84z3kell8c5l6s5ye9"
           },
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NTY1MjMxNzEyMjIxMTgwMjRpbmo="
+            "key": "amount",
+            "value": "56523171222118024inj"
           }
         ],
         "type": "transfer"
@@ -172,8 +172,8 @@
         "attributes": [
           {
             "index": true,
-            "key": "c2VuZGVy",
-            "value": "aW5qMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsNnM1eWU5"
+            "key": "sender",
+            "value": "inj17xpfvakm2amg962yls6f84z3kell8c5l6s5ye9"
           }
         ],
         "type": "message"
@@ -182,13 +182,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MjgyNjE1ODU2MTEwNTkwMS4yMDAwMDAwMDAwMDAwMDAwMDBpbmo="
+            "key": "amount",
+            "value": "2826158561105901.200000000000000000inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFoNHQ1ZHFlbnE4NnpuemEwNnRoYzY0cHp5eHRtZTd6bHR5ZWc4aw=="
+            "key": "validator",
+            "value": "injvaloper1h4t5dqenq86znza06thc64pzyxtme7zltyeg8k"
           }
         ],
         "type": "proposer_reward"
@@ -197,13 +197,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MTQxMzA3OTI4MDU1Mjk1LjA2MDAwMDAwMDAwMDAwMDAwMGluag=="
+            "key": "amount",
+            "value": "141307928055295.060000000000000000inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFoNHQ1ZHFlbnE4NnpuemEwNnRoYzY0cHp5eHRtZTd6bHR5ZWc4aw=="
+            "key": "validator",
+            "value": "injvaloper1h4t5dqenq86znza06thc64pzyxtme7zltyeg8k"
           }
         ],
         "type": "commission"
@@ -212,13 +212,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MjgyNjE1ODU2MTEwNTkwMS4yMDAwMDAwMDAwMDAwMDAwMDBpbmo="
+            "key": "amount",
+            "value": "2826158561105901.200000000000000000inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFoNHQ1ZHFlbnE4NnpuemEwNnRoYzY0cHp5eHRtZTd6bHR5ZWc4aw=="
+            "key": "validator",
+            "value": "injvaloper1h4t5dqenq86znza06thc64pzyxtme7zltyeg8k"
           }
         ],
         "type": "rewards"
@@ -227,13 +227,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MTExOTIxMTc4OTkzMzAyNi4zMzQzNDY4OTg0OTA2NzE3OTBpbmo="
+            "key": "amount",
+            "value": "1119211789933026.334346898490671790inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjF3M3BzbThhOXRkMnF6MDZzNDZjeHNzMDNtejV1bXhheGVndmhocw=="
+            "key": "validator",
+            "value": "injvaloper1w3psm8a9td2qz06s46cxss03mz5umxaxegvhhs"
           }
         ],
         "type": "commission"
@@ -242,13 +242,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MTExOTIxMTc4OTkzMzAyNjMuMzQzNDY4OTg0OTA2NzE3OTAwaW5q"
+            "key": "amount",
+            "value": "11192117899330263.343468984906717900inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjF3M3BzbThhOXRkMnF6MDZzNDZjeHNzMDNtejV1bXhheGVndmhocw=="
+            "key": "validator",
+            "value": "injvaloper1w3psm8a9td2qz06s46cxss03mz5umxaxegvhhs"
           }
         ],
         "type": "rewards"
@@ -257,13 +257,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NjEwNDY1ODQ2MjQxMDU5LjM3NDgzNDg5MjUzNjg3MDAxNGluag=="
+            "key": "amount",
+            "value": "610465846241059.374834892536870014inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFsc3VxcGdtOGtnd3BxOTZld3lldzI2eG5md3luM2xoM25jcmtyaw=="
+            "key": "validator",
+            "value": "injvaloper1lsuqpgm8kgwpq96ewyew26xnfwyn3lh3ncrkrk"
           }
         ],
         "type": "commission"
@@ -272,13 +272,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "ODcyMDk0MDY2MDU4NjU2Mi40OTc2NDEzMjE5NTUyODU5MTVpbmo="
+            "key": "amount",
+            "value": "8720940660586562.497641321955285915inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFsc3VxcGdtOGtnd3BxOTZld3lldzI2eG5md3luM2xoM25jcmtyaw=="
+            "key": "validator",
+            "value": "injvaloper1lsuqpgm8kgwpq96ewyew26xnfwyn3lh3ncrkrk"
           }
         ],
         "type": "rewards"
@@ -287,13 +287,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "Mjg1Njk4MzQzMjQ0ODIwLjAzMDgxODQ5NTkxMTgyMzg4NWluag=="
+            "key": "amount",
+            "value": "285698343244820.030818495911823885inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFqcG51emVzNmhkM2tqeWU5Zjhmc3J1bThkaGo4ZHlsd3E1Z2RjYw=="
+            "key": "validator",
+            "value": "injvaloper1jpnuzes6hd3kjye9f8fsrum8dhj8dylwq5gdcc"
           }
         ],
         "type": "commission"
@@ -302,13 +302,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NDA4MTQwNDkwMzQ5NzQyOS4wMTE2OTI3OTg3NDAzNDEyMTlpbmo="
+            "key": "amount",
+            "value": "4081404903497429.011692798740341219inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFqcG51emVzNmhkM2tqeWU5Zjhmc3J1bThkaGo4ZHlsd3E1Z2RjYw=="
+            "key": "validator",
+            "value": "injvaloper1jpnuzes6hd3kjye9f8fsrum8dhj8dylwq5gdcc"
           }
         ],
         "type": "rewards"
@@ -317,13 +317,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MjgzODYxOTk0MjQxNDIwLjQxMjM2NDQ0ODg5NDc5MjUxMmluag=="
+            "key": "amount",
+            "value": "283861994241420.412364448894792512inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjF5cWRya3lwMzd3NDZhYW50MnU4MHYycmFwdXV6N2VnM3JsNGFyZw=="
+            "key": "validator",
+            "value": "injvaloper1yqdrkyp37w46aant2u80v2rapuuz7eg3rl4arg"
           }
         ],
         "type": "commission"
@@ -332,13 +332,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NDA1NTE3MTM0NjMwNjAwNS44OTA5MjA2OTg0OTcwMzU4ODBpbmo="
+            "key": "amount",
+            "value": "4055171346306005.890920698497035880inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjF5cWRya3lwMzd3NDZhYW50MnU4MHYycmFwdXV6N2VnM3JsNGFyZw=="
+            "key": "validator",
+            "value": "injvaloper1yqdrkyp37w46aant2u80v2rapuuz7eg3rl4arg"
           }
         ],
         "type": "rewards"
@@ -347,13 +347,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MjgxMTAxOTA2MDQyMzcxLjI4OTU2MDQ5MTY0MDAwNDY4OWluag=="
+            "key": "amount",
+            "value": "281101906042371.289560491640004689inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjE4NWpoYXVoeXR0ZzJkNWo1MzVoa3NqMjM0ZG4waGcwenk2cTVlbA=="
+            "key": "validator",
+            "value": "injvaloper185jhauhyttg2d5j535hksj234dn0hg0zy6q5el"
           }
         ],
         "type": "commission"
@@ -362,13 +362,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NDAxNTc0MTUxNDg5MTAxOC40MjIyOTI3Mzc3MTQzNTI3MDBpbmo="
+            "key": "amount",
+            "value": "4015741514891018.422292737714352700inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjE4NWpoYXVoeXR0ZzJkNWo1MzVoa3NqMjM0ZG4waGcwenk2cTVlbA=="
+            "key": "validator",
+            "value": "injvaloper185jhauhyttg2d5j535hksj234dn0hg0zy6q5el"
           }
         ],
         "type": "rewards"
@@ -377,13 +377,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MjgwODI4Njc5NTY5NDQxLjIyNjgwMDA2NzE2MTk5MjY3N2luag=="
+            "key": "amount",
+            "value": "280828679569441.226800067161992677inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFtM2ptYXU5MHZlcGwybnl2aGxqcmtnbDdzcTc4YWxneG1ldzc0dA=="
+            "key": "validator",
+            "value": "injvaloper1m3jmau90vepl2nyvhljrkgl7sq78algxmew74t"
           }
         ],
         "type": "commission"
@@ -392,13 +392,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NDAxMTgzODI3OTU2MzQ0Ni4wOTcxNDM4MTY1OTk4OTUzOTBpbmo="
+            "key": "amount",
+            "value": "4011838279563446.097143816599895390inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFtM2ptYXU5MHZlcGwybnl2aGxqcmtnbDdzcTc4YWxneG1ldzc0dA=="
+            "key": "validator",
+            "value": "injvaloper1m3jmau90vepl2nyvhljrkgl7sq78algxmew74t"
           }
         ],
         "type": "rewards"
@@ -407,13 +407,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MTgyODE4Njc4OTgwOTgzLjE0ODAzNzU0Mzg5NDg5MTU3MGluag=="
+            "key": "amount",
+            "value": "182818678980983.148037543894891570inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFoc3hhbG43NXdqczAzM3Qzc3BkOGEwZ2F3bDRqdnhhd242djg0OQ=="
+            "key": "validator",
+            "value": "injvaloper1hsxaln75wjs033t3spd8a0gawl4jvxawn6v849"
           }
         ],
         "type": "commission"
@@ -422,13 +422,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MzY1NjM3MzU3OTYxOTY2Mi45NjA3NTA4Nzc4OTc4MzE0MDhpbmo="
+            "key": "amount",
+            "value": "3656373579619662.960750877897831408inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFoc3hhbG43NXdqczAzM3Qzc3BkOGEwZ2F3bDRqdnhhd242djg0OQ=="
+            "key": "validator",
+            "value": "injvaloper1hsxaln75wjs033t3spd8a0gawl4jvxawn6v849"
           }
         ],
         "type": "rewards"
@@ -437,13 +437,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MTc1OTc2MDkyODEzNTUzLjYyMTQ4MTU0ODQ1NDUwNTE4MWluag=="
+            "key": "amount",
+            "value": "175976092813553.621481548454505181inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFnNGQ2ZG12bnBnN3c3eXVneTZrcGxuZHA3anBmbWYza3J0c2NocA=="
+            "key": "validator",
+            "value": "injvaloper1g4d6dmvnpg7w7yugy6kplndp7jpfmf3krtschp"
           }
         ],
         "type": "commission"
@@ -452,13 +452,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MzUxOTUyMTg1NjI3MTA3Mi40Mjk2MzA5NjkwOTAxMDM2MThpbmo="
+            "key": "amount",
+            "value": "3519521856271072.429630969090103618inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFnNGQ2ZG12bnBnN3c3eXVneTZrcGxuZHA3anBmbWYza3J0c2NocA=="
+            "key": "validator",
+            "value": "injvaloper1g4d6dmvnpg7w7yugy6kplndp7jpfmf3krtschp"
           }
         ],
         "type": "rewards"
@@ -467,13 +467,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MTQyNzUyMjg2MzI1OTY0LjQxODA1ODA4NTgzNTc3MDE1N2luag=="
+            "key": "amount",
+            "value": "142752286325964.418058085835770157inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFmZnNkdWdyaGZ6ZHl4bHRqdmU4djY4bjZhYXp5YzZwOTd1aGZuMA=="
+            "key": "validator",
+            "value": "injvaloper1ffsdugrhfzdyxltjve8v68n6aazyc6p97uhfn0"
           }
         ],
         "type": "commission"
@@ -482,13 +482,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "Mjg1NTA0NTcyNjUxOTI4OC4zNjExNjE3MTY3MTU0MDMxMzJpbmo="
+            "key": "amount",
+            "value": "2855045726519288.361161716715403132inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFmZnNkdWdyaGZ6ZHl4bHRqdmU4djY4bjZhYXp5YzZwOTd1aGZuMA=="
+            "key": "validator",
+            "value": "injvaloper1ffsdugrhfzdyxltjve8v68n6aazyc6p97uhfn0"
           }
         ],
         "type": "rewards"
@@ -497,13 +497,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MTE0MDUyMTc4NTQxMzM4LjY0NDAzODk4NTkxOTQwNjY2MWluag=="
+            "key": "amount",
+            "value": "114052178541338.644038985919406661inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFoNHQ1ZHFlbnE4NnpuemEwNnRoYzY0cHp5eHRtZTd6bHR5ZWc4aw=="
+            "key": "validator",
+            "value": "injvaloper1h4t5dqenq86znza06thc64pzyxtme7zltyeg8k"
           }
         ],
         "type": "commission"
@@ -512,13 +512,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MjI4MTA0MzU3MDgyNjc3Mi44ODA3Nzk3MTgzODgxMzMyMTZpbmo="
+            "key": "amount",
+            "value": "2281043570826772.880779718388133216inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFoNHQ1ZHFlbnE4NnpuemEwNnRoYzY0cHp5eHRtZTd6bHR5ZWc4aw=="
+            "key": "validator",
+            "value": "injvaloper1h4t5dqenq86znza06thc64pzyxtme7zltyeg8k"
           }
         ],
         "type": "rewards"
@@ -527,13 +527,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NjkwNjMxMTg1MDEwNzAuMjU1MjM5NDU3MjUyNDg5NDIxaW5q"
+            "key": "amount",
+            "value": "69063118501070.255239457252489421inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjE0eWVxM2xrYWpsZGFnZ2oyOGhtcTh4bmc5eHV4N3g1ZzQ2aGV6dg=="
+            "key": "validator",
+            "value": "injvaloper14yeq3lkajldaggj28hmq8xng9xux7x5g46hezv"
           }
         ],
         "type": "commission"
@@ -542,13 +542,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "OTIwODQxNTgwMDE0MjcwLjA2OTg1OTQzMDAzMzE5MjI4NGluag=="
+            "key": "amount",
+            "value": "920841580014270.069859430033192284inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjE0eWVxM2xrYWpsZGFnZ2oyOGhtcTh4bmc5eHV4N3g1ZzQ2aGV6dg=="
+            "key": "validator",
+            "value": "injvaloper14yeq3lkajldaggj28hmq8xng9xux7x5g46hezv"
           }
         ],
         "type": "rewards"
@@ -557,13 +557,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": null
+            "key": "amount",
+            "value": ""
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFhY2d1ZDVxcG4zZnJ3empyYXlxY2RzZHI5dmtsM3A2aHJ6MzR0cw=="
+            "key": "validator",
+            "value": "injvaloper1acgud5qpn3frwzjrayqcdsdr9vkl3p6hrz34ts"
           }
         ],
         "type": "commission"
@@ -572,13 +572,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MzY1MDY3NzcxNzg4NDAxLjAwMjI1MzE2OTAwMTE2NDI2OGluag=="
+            "key": "amount",
+            "value": "365067771788401.002253169001164268inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFhY2d1ZDVxcG4zZnJ3empyYXlxY2RzZHI5dmtsM3A2aHJ6MzR0cw=="
+            "key": "validator",
+            "value": "injvaloper1acgud5qpn3frwzjrayqcdsdr9vkl3p6hrz34ts"
           }
         ],
         "type": "rewards"
@@ -587,13 +587,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": null
+            "key": "amount",
+            "value": ""
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjE0bmNlenJmdTNoeGF1ZWhqbnRmNnBkcG1lN2w1ZXRxc2VwMnFwNg=="
+            "key": "validator",
+            "value": "injvaloper14ncezrfu3hxauehjntf6pdpme7l5etqsep2qp6"
           }
         ],
         "type": "commission"
@@ -602,13 +602,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MjgyMDgyMjg1ODcyODY1Ljg2MzcxMzY2MTQxMTg0MTQwMWluag=="
+            "key": "amount",
+            "value": "282082285872865.863713661411841401inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjE0bmNlenJmdTNoeGF1ZWhqbnRmNnBkcG1lN2w1ZXRxc2VwMnFwNg=="
+            "key": "validator",
+            "value": "injvaloper14ncezrfu3hxauehjntf6pdpme7l5etqsep2qp6"
           }
         ],
         "type": "rewards"
@@ -617,13 +617,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": null
+            "key": "amount",
+            "value": ""
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjF4d3NucTg4a2M4d2NycDM0cWVueGYzZHZobDVuMDJ5ajkzdTc1NQ=="
+            "key": "validator",
+            "value": "injvaloper1xwsnq88kc8wcrp34qenxf3dvhl5n02yj93u755"
           }
         ],
         "type": "commission"
@@ -632,13 +632,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MjMxMTEzNjY0MDc1MDQ0LjkwMzc5NjYzMDIxNjQxMTgyNWluag=="
+            "key": "amount",
+            "value": "231113664075044.903796630216411825inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjF4d3NucTg4a2M4d2NycDM0cWVueGYzZHZobDVuMDJ5ajkzdTc1NQ=="
+            "key": "validator",
+            "value": "injvaloper1xwsnq88kc8wcrp34qenxf3dvhl5n02yj93u755"
           }
         ],
         "type": "rewards"
@@ -647,13 +647,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MTQzMjc0MTc1MTIyODEuODAyMTU5MzMxOTQzODc4Njc1aW5q"
+            "key": "amount",
+            "value": "14327417512281.802159331943878675inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjE2Z3F1dXZrajd5cmV5dm1tbWhhNHVrZTljanRkNnQzbmg1cjc2ZA=="
+            "key": "validator",
+            "value": "injvaloper16gquuvkj7yreyvmmmha4uke9cjtd6t3nh5r76d"
           }
         ],
         "type": "commission"
@@ -662,13 +662,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MjA0Njc3MzkzMDMyNTk3LjE3MzcwNDc0MjA1NTQwOTY0MGluag=="
+            "key": "amount",
+            "value": "204677393032597.173704742055409640inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjE2Z3F1dXZrajd5cmV5dm1tbWhhNHVrZTljanRkNnQzbmg1cjc2ZA=="
+            "key": "validator",
+            "value": "injvaloper16gquuvkj7yreyvmmmha4uke9cjtd6t3nh5r76d"
           }
         ],
         "type": "rewards"
@@ -677,13 +677,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MTQyNzA0OTg2NDI3MzkuMTk2MDA0MTY0MzAyNTA2NDg4aW5q"
+            "key": "amount",
+            "value": "14270498642739.196004164302506488inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFydnF6Zjl1MnV4dHRtc2huMzAyYW5sa25mZ3NhdHJoNXY3Zmw3ZQ=="
+            "key": "validator",
+            "value": "injvaloper1rvqzf9u2uxttmshn302anlknfgsatrh5v7fl7e"
           }
         ],
         "type": "commission"
@@ -692,13 +692,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MTYwMzQyNjgxMzc5MDkyLjA4OTkzNDQzMDM2NTI0MTQzNmluag=="
+            "key": "amount",
+            "value": "160342681379092.089934430365241436inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFydnF6Zjl1MnV4dHRtc2huMzAyYW5sa25mZ3NhdHJoNXY3Zmw3ZQ=="
+            "key": "validator",
+            "value": "injvaloper1rvqzf9u2uxttmshn302anlknfgsatrh5v7fl7e"
           }
         ],
         "type": "rewards"
@@ -707,13 +707,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MTEyMzE5MzcyNTkzMjEuNzI1MDQyMzkxMTY3MzM5NDE4aW5q"
+            "key": "amount",
+            "value": "11231937259321.725042391167339418inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjF2Mnh5bGZleXJ5ODA4bHR0MGh3eGdnenQwZm5zNnV3aDc0bWt1Mw=="
+            "key": "validator",
+            "value": "injvaloper1v2xylfeyry808ltt0hwxggzt0fns6uwh74mku3"
           }
         ],
         "type": "commission"
@@ -722,13 +722,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MTEyMzE5MzcyNTkzMjE3LjI1MDQyMzkxMTY3MzM5NDE3OGluag=="
+            "key": "amount",
+            "value": "112319372593217.250423911673394178inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjF2Mnh5bGZleXJ5ODA4bHR0MGh3eGdnenQwZm5zNnV3aDc0bWt1Mw=="
+            "key": "validator",
+            "value": "injvaloper1v2xylfeyry808ltt0hwxggzt0fns6uwh74mku3"
           }
         ],
         "type": "rewards"
@@ -737,13 +737,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NTk4NTQwNDY4NjE5OS43NzY5MDI1MTYwNDQ1OTIzODBpbmo="
+            "key": "amount",
+            "value": "5985404686199.776902516044592380inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjEyczlkN2w1M2VmMmM4YXZybjdwZ2Q2ZGZlZWcyeXplbDU4enRmeA=="
+            "key": "validator",
+            "value": "injvaloper12s9d7l53ef2c8avrn7pgd6dfeeg2yzel58ztfx"
           }
         ],
         "type": "commission"
@@ -752,13 +752,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NjMwMDQyNTk4NTQ3MzQuNDkzNzEwNjk1MjA2MjM1NTgwaW5q"
+            "key": "amount",
+            "value": "63004259854734.493710695206235580inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjEyczlkN2w1M2VmMmM4YXZybjdwZ2Q2ZGZlZWcyeXplbDU4enRmeA=="
+            "key": "validator",
+            "value": "injvaloper12s9d7l53ef2c8avrn7pgd6dfeeg2yzel58ztfx"
           }
         ],
         "type": "rewards"
@@ -767,13 +767,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NTE2MTI1MzYzODM0Mi44NjE3MjcyMzE5NDMzODU4MTJpbmo="
+            "key": "amount",
+            "value": "5161253638342.861727231943385812inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjF6YWFoeHE4bXk2bnF2cDY0ZmxhY3VneGR5eHA2dG1tOHN0M2hyeg=="
+            "key": "validator",
+            "value": "injvaloper1zaahxq8my6nqvp64flacugxdyxp6tmm8st3hrz"
           }
         ],
         "type": "commission"
@@ -782,13 +782,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NTE2MTI1MzYzODM0MjguNjE3MjcyMzE5NDMzODU4MTIyaW5q"
+            "key": "amount",
+            "value": "51612536383428.617272319433858122inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjF6YWFoeHE4bXk2bnF2cDY0ZmxhY3VneGR5eHA2dG1tOHN0M2hyeg=="
+            "key": "validator",
+            "value": "injvaloper1zaahxq8my6nqvp64flacugxdyxp6tmm8st3hrz"
           }
         ],
         "type": "rewards"
@@ -797,13 +797,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NTUxODU4NjQ4NTU0MS4xODA3MDE3NjQ1NjMyMzgwMjJpbmo="
+            "key": "amount",
+            "value": "5518586485541.180701764563238022inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjF4bmFkZHpqem1sOXV3ODhjcnV5bGptOTN2OHF1ZXhuc2F3dHI0ag=="
+            "key": "validator",
+            "value": "injvaloper1xnaddzjzml9uw88cruyljm93v8quexnsawtr4j"
           }
         ],
         "type": "commission"
@@ -812,13 +812,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MzY3OTA1NzY1NzAyNzQuNTM4MDExNzYzNzU0OTIwMTQ2aW5q"
+            "key": "amount",
+            "value": "36790576570274.538011763754920146inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjF4bmFkZHpqem1sOXV3ODhjcnV5bGptOTN2OHF1ZXhuc2F3dHI0ag=="
+            "key": "validator",
+            "value": "injvaloper1xnaddzjzml9uw88cruyljm93v8quexnsawtr4j"
           }
         ],
         "type": "rewards"
@@ -827,13 +827,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MzEyMzM4MzIxODMzLjY0MDA5NjU5MDI3OTEyMTkxOWluag=="
+            "key": "amount",
+            "value": "312338321833.640096590279121919inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjF5MjhzNWpwYXhnN3FyMDZjMHRoZnFmNXduanVycTZldHg3YXJldA=="
+            "key": "validator",
+            "value": "injvaloper1y28s5jpaxg7qr06c0thfqf5wnjurq6etx7aret"
           }
         ],
         "type": "commission"
@@ -842,13 +842,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MzEyMzM4MzIxODMzNjQuMDA5NjU5MDI3OTEyMTkxODU5aW5q"
+            "key": "amount",
+            "value": "31233832183364.009659027912191859inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjF5MjhzNWpwYXhnN3FyMDZjMHRoZnFmNXduanVycTZldHg3YXJldA=="
+            "key": "validator",
+            "value": "injvaloper1y28s5jpaxg7qr06c0thfqf5wnjurq6etx7aret"
           }
         ],
         "type": "rewards"
@@ -857,13 +857,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "NjczNTI2NzA2OTgyLjgyMzE2Nzc0Njc1NjQwMTYwMmluag=="
+            "key": "amount",
+            "value": "673526706982.823167746756401602inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjF6amp3OHA0bGxnNHVlZTRocXdlMDRrYXQ0aGFmNzM0d2VnY3IyNA=="
+            "key": "validator",
+            "value": "injvaloper1zjjw8p4llg4uee4hqwe04kat4haf734wegcr24"
           }
         ],
         "type": "commission"
@@ -872,13 +872,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "MTM0NzA1MzQxMzk2NTYuNDYzMzU0OTM1MTI4MDMyMDM0aW5q"
+            "key": "amount",
+            "value": "13470534139656.463354935128032034inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjF6amp3OHA0bGxnNHVlZTRocXdlMDRrYXQ0aGFmNzM0d2VnY3IyNA=="
+            "key": "validator",
+            "value": "injvaloper1zjjw8p4llg4uee4hqwe04kat4haf734wegcr24"
           }
         ],
         "type": "rewards"
@@ -887,13 +887,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "OTA5ODI3NDYwNzc1LjI2MTgzNzEzOTQxMDQxMzIxOGluag=="
+            "key": "amount",
+            "value": "909827460775.261837139410413218inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFkNG5kdTdqZWVsbjNxYXh1eWFrYXprbTd2NGtlcDVxcnRkejlrNw=="
+            "key": "validator",
+            "value": "injvaloper1d4ndu7jeeln3qaxuyakazkm7v4kep5qrtdz9k7"
           }
         ],
         "type": "commission"
@@ -902,13 +902,13 @@
         "attributes": [
           {
             "index": true,
-            "key": "YW1vdW50",
-            "value": "OTA5ODI3NDYwNzc1Mi42MTgzNzEzOTQxMDQxMzIxODFpbmo="
+            "key": "amount",
+            "value": "9098274607752.618371394104132181inj"
           },
           {
             "index": true,
-            "key": "dmFsaWRhdG9y",
-            "value": "aW5qdmFsb3BlcjFkNG5kdTdqZWVsbjNxYXh1eWFrYXprbTd2NGtlcDVxcnRkejlrNw=="
+            "key": "validator",
+            "value": "injvaloper1d4ndu7jeeln3qaxuyakazkm7v4kep5qrtdz9k7"
           }
         ],
         "type": "rewards"
@@ -917,58 +917,58 @@
         "attributes": [
           {
             "index": true,
-            "key": "cGFja2V0X2RhdGE=",
-            "value": "eyJhc2tfY291bnQiOiIxNiIsImNhbGxkYXRhIjoiQUFBQUJRQUFBQU5DVkVNQUFBQURSVlJJQUFBQUJGVlRSRlFBQUFBRFNVNUtBQUFBQTBKT1FnQUFBQUE3bXNvQSIsImNsaWVudF9pZCI6IjI4MzEiLCJleGVjdXRlX2dhcyI6IjQwMDAwMCIsImZlZV9saW1pdCI6W3siYW1vdW50IjoiMTAwMCIsImRlbm9tIjoidWJhbmQifV0sIm1pbl9jb3VudCI6IjEwIiwib3JhY2xlX3NjcmlwdF9pZCI6IjIzIiwicHJlcGFyZV9nYXMiOiIyMDAwMCJ9"
+            "key": "packet_data",
+            "value": "eyJhc2tfY291bnQiOiIxNiIsImNhbGxkYXRhIjoiQUFBQUJRQUFBQU5DVkVNQUFBQURSVlJJQUFBQUJGVlRSRlFBQUFBRFNVNUtBQUFBQTBKT1FnQUFBQUE3bXNvQSIsImNsaWVudF9pZCI6IjI4MzEiLCJleGVjdXRlX2dhcyI6IjQwMDAwMCIsImZlZV9saW1pdCI6W3siamountIjoiMTAwMCIsImRlbm9tIjoidWJhbmQifV0sIm1pbl9jb3VudCI6IjEwIiwib3JhY2xlX3NjcmlwdF9pZCI6IjIzIiwicHJlcGFyZV9nYXMiOiIyMDAwMCJ9"
           },
           {
             "index": true,
-            "key": "cGFja2V0X2RhdGFfaGV4",
-            "value": "N2IyMjYxNzM2YjVmNjM2Zjc1NmU3NDIyM2EyMjMxMzYyMjJjMjI2MzYxNmM2YzY0NjE3NDYxMjIzYTIyNDE0MTQxNDE0MjUxNDE0MTQxNDE0ZTQzNTY0NTRkNDE0MTQxNDE0NDUyNTY1MjQ5NDE0MTQxNDE0MjQ2NTY1NDUyNDY1MTQxNDE0MTQxNDQ1MzU1MzU0YjQxNDE0MTQxNDEzMDRhNGY1MTY3NDE0MTQxNDE0MTM3NmQ3MzZmNDEyMjJjMjI2MzZjNjk2NTZlNzQ1ZjY5NjQyMjNhMjIzMjM4MzMzMTIyMmMyMjY1Nzg2NTYzNzU3NDY1NWY2NzYxNzMyMjNhMjIzNDMwMzAzMDMwMzAyMjJjMjI2NjY1NjU1ZjZjNjk2ZDY5NzQyMjNhNWI3YjIyNjE2ZDZmNzU2ZTc0MjIzYTIyMzEzMDMwMzAyMjJjMjI2NDY1NmU2ZjZkMjIzYTIyNzU2MjYxNmU2NDIyN2Q1ZDJjMjI2ZDY5NmU1ZjYzNmY3NTZlNzQyMjNhMjIzMTMwMjIyYzIyNmY3MjYxNjM2YzY1NWY3MzYzNzI2OTcwNzQ1ZjY5NjQyMjNhMjIzMjMzMjIyYzIyNzA3MjY1NzA2MTcyNjU1ZjY3NjE3MzIyM2EyMjMyMzAzMDMwMzAyMjdk"
+            "key": "packet_data_hex",
+            "value": "7b2261736b5f636f756e74223a223136222c2263616c6c64617461223a22414141414251414141414e4356454d414141414452565249414141414246565452465141414141445355354b4141414141304a4f51674141414141376d736f41222c22636c69656e745f6964223a2232383331222c22657865637574655f676173223a22343030303030222c226665655f6c696d6974223a5b7b22616d6f756e74223a2231303030222c2264656e6f6d223a227562616e64227d5d2c226d696e5f636f756e74223a223130222c226f7261636c655f7363726970745f6964223a223233222c22707265706172655f676173223a223230303030227d"
           },
           {
             "index": true,
-            "key": "cGFja2V0X3RpbWVvdXRfaGVpZ2h0",
-            "value": "MC0w"
+            "key": "packet_timeout_height",
+            "value": "0-0"
           },
           {
             "index": true,
-            "key": "cGFja2V0X3RpbWVvdXRfdGltZXN0YW1w",
-            "value": "MTYzNjg5NTAxMzA5OTgwNTc5MQ=="
+            "key": "packet_timeout_timestamp",
+            "value": "1636895013099805791"
           },
           {
             "index": true,
-            "key": "cGFja2V0X3NlcXVlbmNl",
-            "value": "MjgzMQ=="
+            "key": "packet_sequence",
+            "value": "2831"
           },
           {
             "index": true,
-            "key": "cGFja2V0X3NyY19wb3J0",
+            "key": "packet_src_port",
             "value": "b3JhY2xl"
           },
           {
             "index": true,
-            "key": "cGFja2V0X3NyY19jaGFubmVs",
-            "value": "Y2hhbm5lbC0z"
+            "key": "packet_src_channel",
+            "value": "channel-3"
           },
           {
             "index": true,
-            "key": "cGFja2V0X2RzdF9wb3J0",
+            "key": "packet_dst_port",
             "value": "b3JhY2xl"
           },
           {
             "index": true,
-            "key": "cGFja2V0X2RzdF9jaGFubmVs",
-            "value": "Y2hhbm5lbC03"
+            "key": "packet_dst_channel",
+            "value": "channel-7"
           },
           {
             "index": true,
-            "key": "cGFja2V0X2NoYW5uZWxfb3JkZXJpbmc=",
-            "value": "T1JERVJfVU5PUkRFUkVE"
+            "key": "packet_channel_ordering",
+            "value": "ORDER_UNORDERED"
           },
           {
             "index": true,
-            "key": "cGFja2V0X2Nvbm5lY3Rpb24=",
-            "value": "Y29ubmVjdGlvbi02"
+            "key": "packet_connection",
+            "value": "connection-6"
           }
         ],
         "type": "send_packet"
@@ -977,8 +977,8 @@
         "attributes": [
           {
             "index": true,
-            "key": "bW9kdWxl",
-            "value": "aWJjX2NoYW5uZWw="
+            "key": "module",
+            "value": "ibc_channel"
           }
         ],
         "type": "message"
@@ -1006,8 +1006,8 @@
         "attributes": [
           {
             "index": true,
-            "key": "ZGVwb3NpdF91cGRhdGVz",
-            "value": "W3siZGVub20iOiJwZWdneTB4ZEFDMTdGOTU4RDJlZTUyM2EyMjA2MjA2OTk0NTk3QzEzRDgzMWVjNyIsImRlcG9zaXRzIjpbeyJzdWJhY2NvdW50X2lkIjoiQzBiak9YQ09wTmg3MHZ6R0ZoVGhDYXczUzc0QUFBQUFBQUFBQUFBQUFBQT0iLCJkZXBvc2l0Ijp7ImF2YWlsYWJsZV9iYWxhbmNlIjoiOTc2NTEwOTY4MjIuMTk4NjAwMDAwMDAwMDAwMDAwIiwidG90YWxfYmFsYW5jZSI6IjEwMDAwMTgwMTY3OC42OTg2MDAwMDAwMDAwMDAwMDAifX0seyJzdWJhY2NvdW50X2lkIjoiSUxiSThYamJ6R3IyOEorK1RMbmlFMlFhaTg0QUFBQUFBQUFBQUFBQUFBQT0iLCJkZXBvc2l0Ijp7ImF2YWlsYWJsZV9iYWxhbmNlIjoiMTI3NjcyMjA5NjEuMjUyODUyNjAwMDAwMDAwMDAwIiwidG90YWxfYmFsYW5jZSI6IjQ1OTUyMTE2OTAyLjQ3Nzg1MjYwMDAwMDAwMDAwMCJ9fV19LHsiZGVub20iOiJwZWdneTB4NTE0OTEwNzcxQUY5Q2E2NTZhZjg0MGRmZjgzRTgyNjRFY0Y5ODZDQSIsImRlcG9zaXRzIjpbeyJzdWJhY2NvdW50X2lkIjoiTXJGbmcrcWFDR0F0eDVMeVREMTR1NmJqTTlNQUFBQUFBQUFBQUFBQUFBQT0iLCJkZXBvc2l0Ijp7ImF2YWlsYWJsZV9iYWxhbmNlIjoiMTMzMzQ4MDAwMDAwMDAwMDAwMDAwLjAwMDAwMDAwMDAwMDAwMDAwMCIsInRvdGFsX2JhbGFuY2UiOiIzNDA3OTIwMDAwMDAwMDAwMDAwMDAuMDAwMDAwMDAwMDAwMDAwMDAwIn19XX1d"
+            "key": "deposit_updates",
+            "value": "[{\"denom\":\"peggy0xdAC17F958D2ee523a2206206994597C13D831ec7\",\"deposits\":[{\"subaccount_id\":\"C0bjOXCOpNh70vzGFhThCaw3S74AAAAAAAAAAAAAAAA=\",\"deposit\":{\"available_balance\":\"97651096822.198600000000000000\",\"total_balance\":\"100001801678.698600000000000000\"}},{\"subaccount_id\":\"ILbI8XjbzGr28J++TLniE2Qai84AAAAAAAAAAAAAAAA=\",\"deposit\":{\"available_balance\":\"12767220961.252852600000000000\",\"total_balance\":\"45952116902.477852600000000000\"}}]},{\"denom\":\"peggy0x514910771AF9Ca656af840dff83E8264EcF986CA\",\"deposits\":[{\"subaccount_id\":\"MrFng+qaCGAtx5LyTD14u6bjM9MAAAAAAAAAAAAAAAA=\",\"deposit\":{\"available_balance\":\"133348000000000000000.000000000000000000\",\"total_balance\":\"340792000000000000000.000000000000000000\"}}]}]"
           }
         ],
         "type": "injective.exchange.v1beta1.EventBatchDepositUpdate"
@@ -1024,8 +1024,8 @@
             "attributes": [
               {
                 "index": true,
-                "key": "YWNjX3NlcQ==",
-                "value": "aW5qMXgyY2swcWwybmd5eHF0dzhqdGV5YzB0Y2h3bnd4djducGF1bmd0LzMxNTM0MTc="
+                "key": "acc_seq",
+                "value": "inj1x2ck0ql2ngyxqtw8jteyc0tchwnwxv7npaungt/3153417"
               }
             ],
             "type": "tx"
@@ -1034,8 +1034,8 @@
             "attributes": [
               {
                 "index": true,
-                "key": "c2lnbmF0dXJl",
-                "value": "KzArcG5Ca2JvanNwakdRSkl3Y1BFVzNJOUZ6c0RuOFJlbnJ0VmxpVjJ3c3dDTjRVNlQ2VTM1dTVSd2h3eVZ5VGo0QzhDa3pJOVpmR3RjUmN0MFBsR3dBPQ=="
+                "key": "signature",
+                "value": "+0+pnBkbojspjGQJIwcPEW3I9FzsDn8RenrtVliV2wswCN4U6T6U35u5RwhwyVyTj4C8CkzI9ZfGtcRct0PlGwA="
               }
             ],
             "type": "tx"
@@ -1044,13 +1044,13 @@
             "attributes": [
               {
                 "index": true,
-                "key": "c3BlbmRlcg==",
+                "key": "spender",
                 "value": "aW5qMXgyY2swcWwybmd5eHF0dzhqdGV5YzB0Y2h3bnd4djducGF1bmd0"
               },
               {
                 "index": true,
-                "key": "YW1vdW50",
-                "value": "NjA2NzM1MDAwMDAwMDBpbmo="
+                "key": "amount",
+                "value": "60673500000000inj"
               }
             ],
             "type": "coin_spent"
@@ -1059,13 +1059,13 @@
             "attributes": [
               {
                 "index": true,
-                "key": "cmVjZWl2ZXI=",
-                "value": "aW5qMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsNnM1eWU5"
+                "key": "receiver",
+                "value": "inj17xpfvakm2amg962yls6f84z3kell8c5l6s5ye9"
               },
               {
                 "index": true,
-                "key": "YW1vdW50",
-                "value": "NjA2NzM1MDAwMDAwMDBpbmo="
+                "key": "amount",
+                "value": "60673500000000inj"
               }
             ],
             "type": "coin_received"
@@ -1074,18 +1074,18 @@
             "attributes": [
               {
                 "index": true,
-                "key": "cmVjaXBpZW50",
-                "value": "aW5qMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsNnM1eWU5"
+                "key": "recipient",
+                "value": "inj17xpfvakm2amg962yls6f84z3kell8c5l6s5ye9"
               },
               {
                 "index": true,
-                "key": "c2VuZGVy",
+                "key": "sender",
                 "value": "aW5qMXgyY2swcWwybmd5eHF0dzhqdGV5YzB0Y2h3bnd4djducGF1bmd0"
               },
               {
                 "index": true,
-                "key": "YW1vdW50",
-                "value": "NjA2NzM1MDAwMDAwMDBpbmo="
+                "key": "amount",
+                "value": "60673500000000inj"
               }
             ],
             "type": "transfer"
@@ -1094,7 +1094,7 @@
             "attributes": [
               {
                 "index": true,
-                "key": "c2VuZGVy",
+                "key": "sender",
                 "value": "aW5qMXgyY2swcWwybmd5eHF0dzhqdGV5YzB0Y2h3bnd4djducGF1bmd0"
               }
             ],
@@ -1104,8 +1104,8 @@
             "attributes": [
               {
                 "index": true,
-                "key": "ZmVl",
-                "value": "NjA2NzM1MDAwMDAwMDBpbmo="
+                "key": "fee",
+                "value": "60673500000000inj"
               }
             ],
             "type": "tx"
@@ -1114,8 +1114,8 @@
             "attributes": [
               {
                 "index": true,
-                "key": "YWN0aW9u",
-                "value": "L2luamVjdGl2ZS5leGNoYW5nZS52MWJldGExLk1zZ0JhdGNoQ2FuY2VsU3BvdE9yZGVycw=="
+                "key": "action",
+                "value": "/injective.exchange.v1beta1.MsgBatchCancelSpotOrders"
               }
             ],
             "type": "message"
@@ -1124,13 +1124,13 @@
             "attributes": [
               {
                 "index": true,
-                "key": "bWFya2V0X2lk",
-                "value": "IjB4MjY0MTNhNzBjOWI3OGE0OTUwMjNlNWFiODAwM2M5Y2Y5NjNlZjk2M2Y2NzU1ZjhiNTcyNTVmZWI1NzQ0YmYzMSI="
+                "key": "market_id",
+                "value": "\"0x26413a70c9b78a495023e5ab8003c9cf963ef963f6755f8b57255feb5744bf31\""
               },
               {
                 "index": true,
-                "key": "b3JkZXI=",
-                "value": "eyJvcmRlcl9pbmZvIjp7InN1YmFjY291bnRfaWQiOiIweDMyYjE2NzgzZWE5YTA4NjAyZGM3OTJmMjRjM2Q3OGJiYTZlMzMzZDMwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAiLCJmZWVfcmVjaXBpZW50IjoiaW5qMXgyY2swcWwybmd5eHF0dzhqdGV5YzB0Y2h3bnd4djducGF1bmd0IiwicHJpY2UiOiIwLjAwMDAwMDAwMDAzMzg4NzAwMCIsInF1YW50aXR5IjoiMjk1NzIwMDAwMDAwMDAwMDAwMDAuMDAwMDAwMDAwMDAwMDAwMDAwIn0sIm9yZGVyX3R5cGUiOiJTRUxMIiwiZmlsbGFibGUiOiIyOTU3MjAwMDAwMDAwMDAwMDAwMC4wMDAwMDAwMDAwMDAwMDAwMDAiLCJ0cmlnZ2VyX3ByaWNlIjpudWxsLCJvcmRlcl9oYXNoIjoiQ2ZYZktDbnNnMXIyWU1oS0FuMVlDMkZZM2tGVUlnUVVIODB2MmFFZWdtST0ifQ=="
+                "key": "order",
+                "value": "eyJvcmRlcl9pbmZvIjp7InN1YmFjY291bnRfaWQiOiIweDMyYjE2NzgzZWE5YTA4NjAyZGM3OTJmMjRjM2Q3OGJiYTZlMzMzZDMwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAiLCJmZWVfrecipientIjoiaW5qMXgyY2swcWwybmd5eHF0dzhqdGV5YzB0Y2h3bnd4djducGF1bmd0IiwicHJpY2UiOiIwLjAwMDAwMDAwMDAzMzg4NzAwMCIsInF1YW50aXR5IjoiMjk1NzIwMDAwMDAwMDAwMDAwMDAuMDAwMDAwMDAwMDAwMDAwMDAwIn0sIm9yZGVyX3R5cGUiOiJTRUxMIiwiZmlsbGFibGUiOiIyOTU3MjAwMDAwMDAwMDAwMDAwMC4wMDAwMDAwMDAwMDAwMDAwMDAiLCJ0cmlnZ2VyX3ByaWNlIjpudWxsLCJvcmRlcl9oYXNoIjoiQ2ZYZktDbnNnMXIyWU1oS0FuMVlDMkZZM2tGVUlnUVVIODB2MmFFZWdtST0ifQ=="
               }
             ],
             "type": "injective.exchange.v1beta1.EventCancelSpotOrder"
@@ -1150,8 +1150,8 @@
             "attributes": [
               {
                 "index": true,
-                "key": "YWNjX3NlcQ==",
-                "value": "aW5qMXl6bXYzdXRjbTB4eDRhaHNuN2x5ZXcwenpkanA0ejd3bHg0NHZ4LzExMTYxOA=="
+                "key": "acc_seq",
+                "value": "inj1yzmv3utcm0xx4ahsn7lyew0zzdjp4z7wlx44vx/111618"
               }
             ],
             "type": "tx"
@@ -1160,8 +1160,8 @@
             "attributes": [
               {
                 "index": true,
-                "key": "c2lnbmF0dXJl",
-                "value": "VUVqRVpSZGg3WkZhWkdaVjl2R01xK0JnTGRVODhxdXBiaVFUMEhhNUU4cEQ5ZWRYSHlYSVA4SHFjRTBpcWZPQW5INzRJQVJLUjhaQmlKWmZVaUhVRXdFPQ=="
+                "key": "signature",
+                "value": "UEjEZRdh7ZFaZGZV9vGMq+BgLdU88qupbiQT0Ha5E8pD9edXHyXIP8HqcE0iqfOAnH74IARKR8ZBiJZfUiHUEwE="
               }
             ],
             "type": "tx"
@@ -1170,13 +1170,13 @@
             "attributes": [
               {
                 "index": true,
-                "key": "c3BlbmRlcg==",
+                "key": "spender",
                 "value": "aW5qMXl6bXYzdXRjbTB4eDRhaHNuN2x5ZXcwenpkanA0ejd3bHg0NHZ4"
               },
               {
                 "index": true,
-                "key": "YW1vdW50",
-                "value": "NTkzNDAwMDAwMDAwMDBpbmo="
+                "key": "amount",
+                "value": "59340000000000inj"
               }
             ],
             "type": "coin_spent"
@@ -1185,13 +1185,13 @@
             "attributes": [
               {
                 "index": true,
-                "key": "cmVjZWl2ZXI=",
-                "value": "aW5qMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsNnM1eWU5"
+                "key": "receiver",
+                "value": "inj17xpfvakm2amg962yls6f84z3kell8c5l6s5ye9"
               },
               {
                 "index": true,
-                "key": "YW1vdW50",
-                "value": "NTkzNDAwMDAwMDAwMDBpbmo="
+                "key": "amount",
+                "value": "59340000000000inj"
               }
             ],
             "type": "coin_received"
@@ -1200,18 +1200,18 @@
             "attributes": [
               {
                 "index": true,
-                "key": "cmVjaXBpZW50",
-                "value": "aW5qMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsNnM1eWU5"
+                "key": "recipient",
+                "value": "inj17xpfvakm2amg962yls6f84z3kell8c5l6s5ye9"
               },
               {
                 "index": true,
-                "key": "c2VuZGVy",
+                "key": "sender",
                 "value": "aW5qMXl6bXYzdXRjbTB4eDRhaHNuN2x5ZXcwenpkanA0ejd3bHg0NHZ4"
               },
               {
                 "index": true,
-                "key": "YW1vdW50",
-                "value": "NTkzNDAwMDAwMDAwMDBpbmo="
+                "key": "amount",
+                "value": "59340000000000inj"
               }
             ],
             "type": "transfer"
@@ -1220,7 +1220,7 @@
             "attributes": [
               {
                 "index": true,
-                "key": "c2VuZGVy",
+                "key": "sender",
                 "value": "aW5qMXl6bXYzdXRjbTB4eDRhaHNuN2x5ZXcwenpkanA0ejd3bHg0NHZ4"
               }
             ],
@@ -1230,8 +1230,8 @@
             "attributes": [
               {
                 "index": true,
-                "key": "ZmVl",
-                "value": "NTkzNDAwMDAwMDAwMDBpbmo="
+                "key": "fee",
+                "value": "59340000000000inj"
               }
             ],
             "type": "tx"
@@ -1240,8 +1240,8 @@
             "attributes": [
               {
                 "index": true,
-                "key": "YWN0aW9u",
-                "value": "L2luamVjdGl2ZS5leGNoYW5nZS52MWJldGExLk1zZ0JhdGNoQ2FuY2VsU3BvdE9yZGVycw=="
+                "key": "action",
+                "value": "/injective.exchange.v1beta1.MsgBatchCancelSpotOrders"
               }
             ],
             "type": "message"
@@ -1250,13 +1250,13 @@
             "attributes": [
               {
                 "index": true,
-                "key": "bWFya2V0X2lk",
-                "value": "IjB4MjY0MTNhNzBjOWI3OGE0OTUwMjNlNWFiODAwM2M5Y2Y5NjNlZjk2M2Y2NzU1ZjhiNTcyNTVmZWI1NzQ0YmYzMSI="
+                "key": "market_id",
+                "value": "\"0x26413a70c9b78a495023e5ab8003c9cf963ef963f6755f8b57255feb5744bf31\""
               },
               {
                 "index": true,
-                "key": "b3JkZXI=",
-                "value": "eyJvcmRlcl9pbmZvIjp7InN1YmFjY291bnRfaWQiOiIweDIwYjZjOGYxNzhkYmNjNmFmNmYwOWZiZTRjYjllMjEzNjQxYThiY2UwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAiLCJmZWVfcmVjaXBpZW50IjoiaW5qMXl6bXYzdXRjbTB4eDRhaHNuN2x5ZXcwenpkanA0ejd3bHg0NHZ4IiwicHJpY2UiOiIwLjAwMDAwMDAwMDAzMjA1MTAwMCIsInF1YW50aXR5IjoiNTkxNDUwMDAwMDAwMDAwMDAwMDAuMDAwMDAwMDAwMDAwMDAwMDAwIn0sIm9yZGVyX3R5cGUiOiJCVVkiLCJmaWxsYWJsZSI6IjU5MTQ1MDAwMDAwMDAwMDAwMDAwLjAwMDAwMDAwMDAwMDAwMDAwMCIsInRyaWdnZXJfcHJpY2UiOm51bGwsIm9yZGVyX2hhc2giOiI4U0tPN3BMK3JZZXRLL0lTL1hKdnMwanB4TnYreElaNExDR2lyZ3IzTy93PSJ9"
+                "key": "order",
+                "value": "eyJvcmRlcl9pbmZvIjp7InN1YmFjY291bnRfaWQiOiIweDIwYjZjOGYxNzhkYmNjNmFmNmYwOWZiZTRjYjllMjEzNjQxYThiY2UwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAiLCJmZWVfrecipientIjoiaW5qMXl6bXYzdXRjbTB4eDRhaHNuN2x5ZXcwenpkanA0ejd3bHg0NHZ4IiwicHJpY2UiOiIwLjAwMDAwMDAwMDAzMjA1MTAwMCIsInF1YW50aXR5IjoiNTkxNDUwMDAwMDAwMDAwMDAwMDAuMDAwMDAwMDAwMDAwMDAwMDAwIn0sIm9yZGVyX3R5cGUiOiJCVVkiLCJmaWxsYWJsZSI6IjU5MTQ1MDAwMDAwMDAwMDAwMDAwLjAwMDAwMDAwMDAwMDAwMDAwMCIsInRyaWdnZXJfcHJpY2UiOm51bGwsIm9yZGVyX2hhc2giOiI4U0tPN3BMK3JZZXRLL0lTL1hKdnMwanB4TnYreElaNExDR2lyZ3IzTy93PSJ9"
               }
             ],
             "type": "injective.exchange.v1beta1.EventCancelSpotOrder"
@@ -1276,8 +1276,8 @@
             "attributes": [
               {
                 "index": true,
-                "key": "YWNjX3NlcQ==",
-                "value": "aW5qMXBkcnd4d3RzMzZqZHM3N2psbnJwdjk4cHB4a3J3amE3aGMyNjU5LzM3NTY="
+                "key": "acc_seq",
+                "value": "inj1pdrwxwts36jds77jlnrpv98ppxkrwja7hc2659/3756"
               }
             ],
             "type": "tx"
@@ -1286,8 +1286,8 @@
             "attributes": [
               {
                 "index": true,
-                "key": "c2lnbmF0dXJl",
-                "value": "ajJ6OE5HNzE4U3RIRkRxMW5aTlk3UDhDN2l5K1JUWTlCckhHeEJRYkZ1dzM4Mk4xL05yeWRsVURUdjBtd3ZOZHR2bTVxS285RzZNa3hFZWVqeVhIVEE9PQ=="
+                "key": "signature",
+                "value": "j2z8NG718StHFDq1nZNY7P8C7iy+RTY9BrHGxBQbFuw382N1/NrydlUDTv0mwvNdtvm5qKo9G6MkxEeejyXHTA=="
               }
             ],
             "type": "tx"
@@ -1296,13 +1296,13 @@
             "attributes": [
               {
                 "index": true,
-                "key": "c3BlbmRlcg==",
+                "key": "spender",
                 "value": "aW5qMXBkcnd4d3RzMzZqZHM3N2psbnJwdjk4cHB4a3J3amE3aGMyNjU5"
               },
               {
                 "index": true,
-                "key": "YW1vdW50",
-                "value": "NDYwODM1MDAwMDAwMDBpbmo="
+                "key": "amount",
+                "value": "46083500000000inj"
               }
             ],
             "type": "coin_spent"
@@ -1311,13 +1311,13 @@
             "attributes": [
               {
                 "index": true,
-                "key": "cmVjZWl2ZXI=",
-                "value": "aW5qMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsNnM1eWU5"
+                "key": "receiver",
+                "value": "inj17xpfvakm2amg962yls6f84z3kell8c5l6s5ye9"
               },
               {
                 "index": true,
-                "key": "YW1vdW50",
-                "value": "NDYwODM1MDAwMDAwMDBpbmo="
+                "key": "amount",
+                "value": "46083500000000inj"
               }
             ],
             "type": "coin_received"
@@ -1326,18 +1326,18 @@
             "attributes": [
               {
                 "index": true,
-                "key": "cmVjaXBpZW50",
-                "value": "aW5qMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsNnM1eWU5"
+                "key": "recipient",
+                "value": "inj17xpfvakm2amg962yls6f84z3kell8c5l6s5ye9"
               },
               {
                 "index": true,
-                "key": "c2VuZGVy",
+                "key": "sender",
                 "value": "aW5qMXBkcnd4d3RzMzZqZHM3N2psbnJwdjk4cHB4a3J3amE3aGMyNjU5"
               },
               {
                 "index": true,
-                "key": "YW1vdW50",
-                "value": "NDYwODM1MDAwMDAwMDBpbmo="
+                "key": "amount",
+                "value": "46083500000000inj"
               }
             ],
             "type": "transfer"
@@ -1346,7 +1346,7 @@
             "attributes": [
               {
                 "index": true,
-                "key": "c2VuZGVy",
+                "key": "sender",
                 "value": "aW5qMXBkcnd4d3RzMzZqZHM3N2psbnJwdjk4cHB4a3J3amE3aGMyNjU5"
               }
             ],
@@ -1356,8 +1356,8 @@
             "attributes": [
               {
                 "index": true,
-                "key": "ZmVl",
-                "value": "NDYwODM1MDAwMDAwMDBpbmo="
+                "key": "fee",
+                "value": "46083500000000inj"
               }
             ],
             "type": "tx"
@@ -1366,8 +1366,8 @@
             "attributes": [
               {
                 "index": true,
-                "key": "YWN0aW9u",
-                "value": "L2luamVjdGl2ZS5leGNoYW5nZS52MWJldGExLk1zZ0NhbmNlbFNwb3RPcmRlcg=="
+                "key": "action",
+                "value": "/injective.exchange.v1beta1.MsgCancelSpotOrder"
               }
             ],
             "type": "message"
@@ -1376,13 +1376,13 @@
             "attributes": [
               {
                 "index": true,
-                "key": "b3JkZXI=",
-                "value": "eyJvcmRlcl9pbmZvIjp7InN1YmFjY291bnRfaWQiOiIweDBiNDZlMzM5NzA4ZWE0ZDg3YmQyZmNjNjE2MTRlMTA5YWMzNzRiYmUwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAiLCJmZWVfcmVjaXBpZW50IjoiaW5qMXBkcnd4d3RzMzZqZHM3N2psbnJwdjk4cHB4a3J3amE3aGMyNjU5IiwicHJpY2UiOiIwLjAwMDAwMDAwMDAxMjAwMDAwMCIsInF1YW50aXR5IjoiMTAwMDAwMDAwMDAwMDAwMDAwMC4wMDAwMDAwMDAwMDAwMDAwMDAifSwib3JkZXJfdHlwZSI6IkJVWSIsImZpbGxhYmxlIjoiMTAwMDAwMDAwMDAwMDAwMDAwMC4wMDAwMDAwMDAwMDAwMDAwMDAiLCJ0cmlnZ2VyX3ByaWNlIjoiMC4wMDAwMDAwMDAwMDAwMDAwMDAiLCJvcmRlcl9oYXNoIjoicC9uQmFkcHVXbGhhM0EwNThYMWk3WkxhS0xrL0pJcTVSNGJVa0hUWTVFdz0ifQ=="
+                "key": "order",
+                "value": "eyJvcmRlcl9pbmZvIjp7InN1YmFjY291bnRfaWQiOiIweDBiNDZlMzM5NzA4ZWE0ZDg3YmQyZmNjNjE2MTRlMTA5YWMzNzRiYmUwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAiLCJmZWVfrecipientIjoiaW5qMXBkcnd4d3RzMzZqZHM3N2psbnJwdjk4cHB4a3J3amE3aGMyNjU5IiwicHJpY2UiOiIwLjAwMDAwMDAwMDAxMjAwMDAwMCIsInF1YW50aXR5IjoiMTAwMDAwMDAwMDAwMDAwMDAwMC4wMDAwMDAwMDAwMDAwMDAwMDAifSwib3JkZXJfdHlwZSI6IkJVWSIsImZpbGxhYmxlIjoiMTAwMDAwMDAwMDAwMDAwMDAwMC4wMDAwMDAwMDAwMDAwMDAwMDAiLCJ0cmlnZ2VyX3ByaWNlIjoiMC4wMDAwMDAwMDAwMDAwMDAwMDAiLCJvcmRlcl9oYXNoIjoicC9uQmFkcHVXbGhhM0EwNThYMWk3WkxhS0xrL0pJcTVSNGJVa0hUWTVFdz0ifQ=="
               },
               {
                 "index": true,
-                "key": "bWFya2V0X2lk",
-                "value": "IjB4YTUwOGNiMzI5MjMzMjM2NzlmMjlhMDMyYzcwMzQyYzE0N2MxN2QwMTQ1NjI1OTIyYjBlZjIyZTk1NWM4NDRjMCI="
+                "key": "market_id",
+                "value": "\"0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0\""
               }
             ],
             "type": "injective.exchange.v1beta1.EventCancelSpotOrder"
@@ -1402,8 +1402,8 @@
             "attributes": [
               {
                 "index": true,
-                "key": "YWNjX3NlcQ==",
-                "value": "aW5qMXdoNnYyZHY2NHk2ZjhhNGtjem5yY3R1NG43ZzIzYXg5eDY4cjU3LzE="
+                "key": "acc_seq",
+                "value": "inj1wh6v2dv64y6f8a4kcznrctu4n7g23ax9x68r57/1"
               }
             ],
             "type": "tx"
@@ -1412,8 +1412,8 @@
             "attributes": [
               {
                 "index": true,
-                "key": "c2lnbmF0dXJl",
-                "value": "SkJkQTJtSW9WNkxLcUVtTHh5NnBJL1lKOWJ3TnJ2Wkt1RWdoQkgyWlpQVmg0dnhpaGRpaDhFYm9LNFdWd042R0NYTThjNHBDL2lpa1dzTGZjVlRLSWdBPQ=="
+                "key": "signature",
+                "value": "JBdA2mIoV6LKqEmLxy6pI/YJ9bwNrvZKuEghBH2ZZPVh4vxihdih8EboK4WVwN6GCXM8c4pC/iikWsLfcVTKIgA="
               }
             ],
             "type": "tx"
@@ -1422,13 +1422,13 @@
             "attributes": [
               {
                 "index": true,
-                "key": "c3BlbmRlcg==",
+                "key": "spender",
                 "value": "aW5qMXdoNnYyZHY2NHk2ZjhhNGtjem5yY3R1NG43ZzIzYXg5eDY4cjU3"
               },
               {
                 "index": true,
-                "key": "YW1vdW50",
-                "value": "MjAwMDAwMDAwMDAwMDAwaW5q"
+                "key": "amount",
+                "value": "200000000000000inj"
               }
             ],
             "type": "coin_spent"
@@ -1437,13 +1437,13 @@
             "attributes": [
               {
                 "index": true,
-                "key": "cmVjZWl2ZXI=",
-                "value": "aW5qMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsNnM1eWU5"
+                "key": "receiver",
+                "value": "inj17xpfvakm2amg962yls6f84z3kell8c5l6s5ye9"
               },
               {
                 "index": true,
-                "key": "YW1vdW50",
-                "value": "MjAwMDAwMDAwMDAwMDAwaW5q"
+                "key": "amount",
+                "value": "200000000000000inj"
               }
             ],
             "type": "coin_received"
@@ -1452,18 +1452,18 @@
             "attributes": [
               {
                 "index": true,
-                "key": "cmVjaXBpZW50",
-                "value": "aW5qMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsNnM1eWU5"
+                "key": "recipient",
+                "value": "inj17xpfvakm2amg962yls6f84z3kell8c5l6s5ye9"
               },
               {
                 "index": true,
-                "key": "c2VuZGVy",
+                "key": "sender",
                 "value": "aW5qMXdoNnYyZHY2NHk2ZjhhNGtjem5yY3R1NG43ZzIzYXg5eDY4cjU3"
               },
               {
                 "index": true,
-                "key": "YW1vdW50",
-                "value": "MjAwMDAwMDAwMDAwMDAwaW5q"
+                "key": "amount",
+                "value": "200000000000000inj"
               }
             ],
             "type": "transfer"
@@ -1472,7 +1472,7 @@
             "attributes": [
               {
                 "index": true,
-                "key": "c2VuZGVy",
+                "key": "sender",
                 "value": "aW5qMXdoNnYyZHY2NHk2ZjhhNGtjem5yY3R1NG43ZzIzYXg5eDY4cjU3"
               }
             ],
@@ -1482,8 +1482,8 @@
             "attributes": [
               {
                 "index": true,
-                "key": "YWN0aW9u",
-                "value": "L2Nvc21vcy5zdGFraW5nLnYxYmV0YTEuTXNnRGVsZWdhdGU="
+                "key": "action",
+                "value": "/cosmos.staking.v1beta1.MsgDelegate"
               }
             ],
             "type": "message"
@@ -1492,13 +1492,13 @@
             "attributes": [
               {
                 "index": true,
-                "key": "c3BlbmRlcg==",
+                "key": "spender",
                 "value": "aW5qMXdoNnYyZHY2NHk2ZjhhNGtjem5yY3R1NG43ZzIzYXg5eDY4cjU3"
               },
               {
                 "index": true,
-                "key": "YW1vdW50",
-                "value": "NDk5ODAwMDAwMDAwMDAwMDAwMDBpbmo="
+                "key": "amount",
+                "value": "49980000000000000000inj"
               }
             ],
             "type": "coin_spent"
@@ -1507,13 +1507,13 @@
             "attributes": [
               {
                 "index": true,
-                "key": "cmVjZWl2ZXI=",
-                "value": "aW5qMWZsNDh2c25tc2R6Y3Y4NXE1ZDJxNHo1YWpkaGE4eXUzbGo3dHQw"
+                "key": "receiver",
+                "value": "inj1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3lj7tt0"
               },
               {
                 "index": true,
-                "key": "YW1vdW50",
-                "value": "NDk5ODAwMDAwMDAwMDAwMDAwMDBpbmo="
+                "key": "amount",
+                "value": "49980000000000000000inj"
               }
             ],
             "type": "coin_received"
@@ -1522,18 +1522,18 @@
             "attributes": [
               {
                 "index": true,
-                "key": "dmFsaWRhdG9y",
-                "value": "aW5qdmFsb3BlcjFoNHQ1ZHFlbnE4NnpuemEwNnRoYzY0cHp5eHRtZTd6bHR5ZWc4aw=="
+                "key": "validator",
+                "value": "injvaloper1h4t5dqenq86znza06thc64pzyxtme7zltyeg8k"
               },
               {
                 "index": true,
-                "key": "YW1vdW50",
-                "value": "NDk5ODAwMDAwMDAwMDAwMDAwMDBpbmo="
+                "key": "amount",
+                "value": "49980000000000000000inj"
               },
               {
                 "index": true,
-                "key": "bmV3X3NoYXJlcw==",
-                "value": "NDk5ODAwMDAwMDAwMDAwMDAwMDAuMDAwMDAwMDAwMDAwMDAwMDAw"
+                "key": "new_shares",
+                "value": "49980000000000000000.000000000000000000"
               }
             ],
             "type": "delegate"
@@ -1542,12 +1542,12 @@
             "attributes": [
               {
                 "index": true,
-                "key": "bW9kdWxl",
-                "value": "c3Rha2luZw=="
+                "key": "module",
+                "value": "staking"
               },
               {
                 "index": true,
-                "key": "c2VuZGVy",
+                "key": "sender",
                 "value": "aW5qMXdoNnYyZHY2NHk2ZjhhNGtjem5yY3R1NG43ZzIzYXg5eDY4cjU3"
               }
             ],

--- a/rpc/tests/kvstore_fixtures/incoming/broadcast_tx_commit.json
+++ b/rpc/tests/kvstore_fixtures/incoming/broadcast_tx_commit.json
@@ -21,23 +21,23 @@
           "attributes": [
             {
               "index": true,
-              "key": "Y3JlYXRvcg==",
-              "value": "Q29zbW9zaGkgTmV0b3dva28="
+              "key": "creator",
+              "value": "Cosmoshi Netowoko"
             },
             {
               "index": true,
-              "key": "a2V5",
-              "value": "Y29tbWl0LWtleQ=="
+              "key": "key",
+              "value": "commit-key"
             },
             {
               "index": true,
-              "key": "aW5kZXhfa2V5",
-              "value": "aW5kZXggaXMgd29ya2luZw=="
+              "key": "index_key",
+              "value": "index is working"
             },
             {
               "index": false,
-              "key": "bm9pbmRleF9rZXk=",
-              "value": "aW5kZXggaXMgd29ya2luZw=="
+              "key": "noindex_key",
+              "value": "index is working"
             }
           ],
           "type": "app"

--- a/rpc/tests/kvstore_fixtures/incoming/subscribe_txs_0.json
+++ b/rpc/tests/kvstore_fixtures/incoming/subscribe_txs_0.json
@@ -13,24 +13,25 @@
                 "attributes": [
                   {
                     "index": true,
-                    "key": "Y3JlYXRvcg==",
-                    "value": "Q29zbW9zaGkgTmV0b3dva28="
+                    "key": "creator",
+                    "value": "Cosmoshi Netowoko"
                   },
                   {
                     "index": true,
-                    "key": "a2V5",
-                    "value": "dHgw"
+                    "key": "key",
+                    "value": "tx0"
                   },
                   {
                     "index": true,
-                    "key": "aW5kZXhfa2V5",
-                    "value": "aW5kZXggaXMgd29ya2luZw=="
+                    "key": "index_key",
+                    "value": "index is working"
                   },
                   {
                     "index": false,
-                    "key": "bm9pbmRleF9rZXk=",
-                    "value": "aW5kZXggaXMgd29ya2luZw=="
+                    "key": "noindex_key",
+                    "value": "index is working"
                   }
+
                 ],
                 "type": "app"
               }

--- a/rpc/tests/kvstore_fixtures/incoming/subscribe_txs_1.json
+++ b/rpc/tests/kvstore_fixtures/incoming/subscribe_txs_1.json
@@ -14,23 +14,23 @@
                 "attributes": [
                   {
                     "index": true,
-                    "key": "Y3JlYXRvcg==",
-                    "value": "Q29zbW9zaGkgTmV0b3dva28="
+                    "key": "creator",
+                    "value": "Cosmoshi Netowoko"
                   },
                   {
                     "index": true,
-                    "key": "a2V5",
-                    "value": "dHgx"
+                    "key": "key",
+                    "value": "tx1"
                   },
                   {
                     "index": true,
-                    "key": "aW5kZXhfa2V5",
-                    "value": "aW5kZXggaXMgd29ya2luZw=="
+                    "key": "index_key",
+                    "value": "index is working"
                   },
                   {
                     "index": false,
-                    "key": "bm9pbmRleF9rZXk=",
-                    "value": "aW5kZXggaXMgd29ya2luZw=="
+                    "key": "noindex_key",
+                    "value": "index is working"
                   }
                 ],
                 "type": "app"

--- a/rpc/tests/kvstore_fixtures/incoming/subscribe_txs_2.json
+++ b/rpc/tests/kvstore_fixtures/incoming/subscribe_txs_2.json
@@ -13,23 +13,23 @@
                 "attributes": [
                   {
                     "index": true,
-                    "key": "Y3JlYXRvcg==",
-                    "value": "Q29zbW9zaGkgTmV0b3dva28="
+                    "key": "creator",
+                    "value": "Cosmoshi Netowoko"
                   },
                   {
                     "index": true,
-                    "key": "a2V5",
-                    "value": "dHgy"
+                    "key": "key",
+                    "value": "tx2"
                   },
                   {
                     "index": true,
-                    "key": "aW5kZXhfa2V5",
-                    "value": "aW5kZXggaXMgd29ya2luZw=="
+                    "key": "index_key",
+                    "value": "index is working"
                   },
                   {
                     "index": false,
-                    "key": "bm9pbmRleF9rZXk=",
-                    "value": "aW5kZXggaXMgd29ya2luZw=="
+                    "key": "noindex_key",
+                    "value": "index is working"
                   }
                 ],
                 "type": "app"

--- a/rpc/tests/kvstore_fixtures/incoming/subscribe_txs_3.json
+++ b/rpc/tests/kvstore_fixtures/incoming/subscribe_txs_3.json
@@ -13,23 +13,23 @@
                 "attributes": [
                   {
                     "index": true,
-                    "key": "Y3JlYXRvcg==",
-                    "value": "Q29zbW9zaGkgTmV0b3dva28="
+                    "key": "creator",
+                    "value": "Cosmoshi Netowoko"
                   },
                   {
                     "index": true,
-                    "key": "a2V5",
-                    "value": "dHgz"
+                    "key": "key",
+                    "value": "tx3"
                   },
                   {
                     "index": true,
-                    "key": "aW5kZXhfa2V5",
-                    "value": "aW5kZXggaXMgd29ya2luZw=="
+                    "key": "index_key",
+                    "value": "index is working"
                   },
                   {
                     "index": false,
-                    "key": "bm9pbmRleF9rZXk=",
-                    "value": "aW5kZXggaXMgd29ya2luZw=="
+                    "key": "noindex_key",
+                    "value": "index is working"
                   }
                 ],
                 "type": "app"

--- a/rpc/tests/kvstore_fixtures/incoming/subscribe_txs_4.json
+++ b/rpc/tests/kvstore_fixtures/incoming/subscribe_txs_4.json
@@ -13,23 +13,23 @@
                 "attributes": [
                   {
                     "index": true,
-                    "key": "Y3JlYXRvcg==",
-                    "value": "Q29zbW9zaGkgTmV0b3dva28="
+                    "key": "creator",
+                    "value": "Cosmoshi Netowoko"
                   },
                   {
                     "index": true,
-                    "key": "a2V5",
-                    "value": "dHg0"
+                    "key": "key",
+                    "value": "tx4"
                   },
                   {
                     "index": true,
-                    "key": "aW5kZXhfa2V5",
-                    "value": "aW5kZXggaXMgd29ya2luZw=="
+                    "key": "index_key",
+                    "value": "index is working"
                   },
                   {
                     "index": false,
-                    "key": "bm9pbmRleF9rZXk=",
-                    "value": "aW5kZXggaXMgd29ya2luZw=="
+                    "key": "noindex_key",
+                    "value": "index is working"
                   }
                 ],
                 "type": "app"

--- a/tendermint/src/abci/tag.rs
+++ b/tendermint/src/abci/tag.rs
@@ -4,7 +4,6 @@ use crate::error::Error;
 use crate::prelude::*;
 use core::{fmt, str::FromStr};
 use serde::{Deserialize, Serialize};
-use tendermint_proto::serializers::bytes::base64string;
 
 /// Tags
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -18,13 +17,7 @@ pub struct Tag {
 
 /// Tag keys
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct Key(
-    #[serde(
-        serialize_with = "base64string::serialize",
-        deserialize_with = "base64string::deserialize_to_string"
-    )]
-    String,
-);
+pub struct Key(String);
 
 impl AsRef<str> for Key {
     fn as_ref(&self) -> &str {
@@ -48,13 +41,7 @@ impl fmt::Display for Key {
 
 /// Tag values
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct Value(
-    #[serde(
-        serialize_with = "base64string::serialize",
-        deserialize_with = "base64string::deserialize_to_string"
-    )]
-    String,
-);
+pub struct Value(String);
 
 impl AsRef<str> for Value {
     fn as_ref(&self) -> &str {
@@ -82,7 +69,7 @@ mod test {
 
     #[test]
     fn tag_serde() {
-        let json = r#"{"key": "cGFja2V0X3RpbWVvdXRfaGVpZ2h0", "value": "MC00ODQw"}"#;
+        let json = r#"{"key": "packet_timeout_height", "value": "0-4840"}"#;
         let tag: Tag = serde_json::from_str(json).unwrap();
         assert_eq!("packet_timeout_height", tag.key.0);
         assert_eq!("0-4840", tag.value.0);


### PR DESCRIPTION
The type of EventAttribute's tag was changed from `bytes` to `string` in https://github.com/tendermint/tendermint/pull/6408.