### PR TITLE
Make parameters Option in ConsensusParams

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -529,8 +529,8 @@ pub struct MempoolConfig {
 
     /// WAL dir
     #[serde(
-    deserialize_with = "deserialize_optional_value",
-    serialize_with = "serialize_optional_value"
+        deserialize_with = "deserialize_optional_value",
+        serialize_with = "serialize_optional_value"
     )]
     pub wal_dir: Option<PathBuf>,
 
@@ -655,8 +655,8 @@ pub struct StatesyncConfig {
     /// For Cosmos SDK-based chains, trust-period should usually be about 2/3 of the unbonding time
     /// (~2 weeks) during which they can be financially punished (slashed) for misbehavior.
     #[serde(
-    serialize_with = "serialize_comma_separated_list",
-    deserialize_with = "deserialize_comma_separated_list"
+        serialize_with = "serialize_comma_separated_list",
+        deserialize_with = "deserialize_comma_separated_list"
     )]
     pub rpc_servers: Vec<String>,
 

--- a/rpc/tests/kvstore_fixtures.rs
+++ b/rpc/tests/kvstore_fixtures.rs
@@ -706,19 +706,35 @@ fn incoming_fixtures() {
             "consensus_params" => {
                 let result = endpoint::consensus_params::Response::from_string(content).unwrap();
                 assert_eq!(u64::from(result.block_height), 10_u64);
-                assert_eq!(result.consensus_params.block.max_bytes, 22020096_u64);
-                assert_eq!(result.consensus_params.block.max_gas, -1_i64);
                 assert_eq!(
-                    result.consensus_params.evidence.max_age_duration,
+                    result.consensus_params.block.clone().unwrap().max_bytes,
+                    22020096_u64
+                );
+                assert_eq!(result.consensus_params.block.unwrap().max_gas, -1_i64);
+                assert_eq!(
+                    result
+                        .consensus_params
+                        .evidence
+                        .clone()
+                        .unwrap()
+                        .max_age_duration,
                     Duration(core::time::Duration::from_nanos(172800000000000_u64))
                 );
                 assert_eq!(
-                    result.consensus_params.evidence.max_age_num_blocks,
+                    result
+                        .consensus_params
+                        .evidence
+                        .clone()
+                        .unwrap()
+                        .max_age_num_blocks,
                     100000_u64
                 );
-                assert_eq!(result.consensus_params.evidence.max_bytes, 1048576_i64);
                 assert_eq!(
-                    result.consensus_params.validator.pub_key_types,
+                    result.consensus_params.evidence.unwrap().max_bytes,
+                    1048576_i64
+                );
+                assert_eq!(
+                    result.consensus_params.validator.unwrap().pub_key_types,
                     vec![public_key::Algorithm::Ed25519]
                 );
             }
@@ -729,34 +745,61 @@ fn incoming_fixtures() {
                 let result = endpoint::genesis::Response::from_string(content).unwrap();
                 assert!(result.genesis.app_hash.is_empty());
                 assert_eq!(result.genesis.chain_id.as_str(), CHAIN_ID);
-                assert_eq!(result.genesis.consensus_params.block.max_bytes, 22020096);
-                assert_eq!(result.genesis.consensus_params.block.max_gas, -1);
+                assert_eq!(
+                    result
+                        .genesis
+                        .consensus_params
+                        .block
+                        .clone()
+                        .unwrap()
+                        .max_bytes,
+                    22020096
+                );
+                assert_eq!(result.genesis.consensus_params.block.unwrap().max_gas, -1);
                 assert_eq!(
                     result
                         .genesis
                         .consensus_params
                         .evidence
+                        .clone()
+                        .unwrap()
                         .max_age_duration
                         .0
                         .as_nanos(),
                     172800000000000
                 );
                 assert_eq!(
-                    result.genesis.consensus_params.evidence.max_age_num_blocks,
+                    result
+                        .genesis
+                        .consensus_params
+                        .evidence
+                        .clone()
+                        .unwrap()
+                        .max_age_num_blocks,
                     100000
                 );
-                assert_eq!(result.genesis.consensus_params.evidence.max_bytes, 1048576);
+                assert_eq!(
+                    result.genesis.consensus_params.evidence.unwrap().max_bytes,
+                    1048576
+                );
                 assert_eq!(
                     result
                         .genesis
                         .consensus_params
                         .validator
+                        .clone()
+                        .unwrap()
                         .pub_key_types
                         .len(),
                     1
                 );
                 assert_eq!(
-                    result.genesis.consensus_params.validator.pub_key_types[0],
+                    result
+                        .genesis
+                        .consensus_params
+                        .validator
+                        .unwrap()
+                        .pub_key_types[0],
                     tendermint::public_key::Algorithm::Ed25519
                 );
                 assert!(result.genesis.consensus_params.version.is_none());

--- a/testgen/src/consensus.rs
+++ b/testgen/src/consensus.rs
@@ -5,18 +5,18 @@ use tendermint::{block, consensus, duration::Duration, evidence, public_key::Alg
 /// from here
 pub fn default_consensus_params() -> consensus::Params {
     consensus::Params {
-        block: block::Size {
+        block: Some(block::Size {
             max_bytes: 22020096,
             max_gas: -1, // Tendetmint-go also has TimeIotaMs: 1000, // 1s
-        },
-        evidence: evidence::Params {
+        }),
+        evidence: Some(evidence::Params {
             max_age_num_blocks: 100000,
             max_age_duration: Duration(std::time::Duration::new(48 * 3600, 0)),
             max_bytes: 1048576,
-        },
-        validator: consensus::params::ValidatorParams {
+        }),
+        validator: Some(consensus::params::ValidatorParams {
             pub_key_types: vec![Algorithm::Ed25519],
-        },
+        }),
         version: Some(VersionParams::default()),
     }
 }


### PR DESCRIPTION
When `ConsensusParams` wasn't null, the parse failed because Tendermint omitted a null parameter like `block` or `validator`.
We could handle these parameters as `Option` to be parsed in RPC `block_result`.

For example, Tendermint returned the following Json. `consensus_param_updates` had only `evidence`. It couldn't be parsed because `block` and `validator` were omitted.
```shell
% curl -X GET "http://127.0.0.1:27657/block_results?height=321" -H "accept: application/json"
{
  "jsonrpc": "2.0",
  "id": -1,
  "result": {
    "height": "321",
    "txs_results": null,
    "begin_block_events": null,
    "end_block_events": null,
    "validator_updates": null,
    "consensus_param_updates": {
      "evidence": {
        "max_age_num_blocks": "8",
        "max_age_duration": "2000000000"
      }
    }
  }
}
```