### PR TITLE
Pemit an empty app_state in a Tendermint genesis.json

### DIFF
--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -234,7 +234,7 @@ pub trait Client {
     /// `/genesis`: get genesis file.
     async fn genesis<AppState>(&self) -> Result<Genesis<AppState>, Error>
     where
-        AppState: fmt::Debug + Serialize + DeserializeOwned + Send,
+        AppState: fmt::Debug + Default + Serialize + DeserializeOwned + Send,
     {
         Ok(self.perform(genesis::Request::default()).await?.genesis)
     }

--- a/rpc/src/endpoint/genesis.rs
+++ b/rpc/src/endpoint/genesis.rs
@@ -17,7 +17,7 @@ impl<AppState> Default for Request<AppState> {
 
 impl<AppState> crate::Request for Request<AppState>
 where
-    AppState: fmt::Debug + Serialize + DeserializeOwned + Send,
+    AppState: fmt::Debug + Default + Serialize + DeserializeOwned + Send,
 {
     type Response = Response<AppState>;
 
@@ -27,15 +27,21 @@ where
 }
 
 impl<AppState> crate::SimpleRequest for Request<AppState> where
-    AppState: fmt::Debug + Serialize + DeserializeOwned + Send
+    AppState: fmt::Debug + Default + Serialize + DeserializeOwned + Send
 {
 }
 
 /// Block responses
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Response<AppState> {
+pub struct Response<AppState>
+where
+    AppState: Default,
+{
     /// Genesis data
     pub genesis: Genesis<AppState>,
 }
 
-impl<AppState> crate::Response for Response<AppState> where AppState: Serialize + DeserializeOwned {}
+impl<AppState> crate::Response for Response<AppState> where
+    AppState: Default + Serialize + DeserializeOwned
+{
+}

--- a/tendermint/src/genesis.rs
+++ b/tendermint/src/genesis.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// Genesis data
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Genesis<AppState = serde_json::Value> {
+pub struct Genesis<AppState: Default = serde_json::Value> {
     /// Time of genesis
     pub genesis_time: Time,
 
@@ -30,5 +30,6 @@ pub struct Genesis<AppState = serde_json::Value> {
     pub app_hash: Vec<u8>,
 
     /// App state
+    #[serde(default)]
     pub app_state: AppState,
 }


### PR DESCRIPTION
The `genesis.json` file generated when running `tendermint init` for Tendermint v0.37.x may not have an "app_state" key. When deserializing a `genesis.json` to a `Genesis` struct, we should permit this key to be missing.

This was the case in tendermint-rs `v0.23.5`, but stopped working in `v0.23.6`, which `eth-bridge-integration` branch is based on.

This PR may be appropriate for upstream (although there are a lot of changes going on there, we should probably try catching up to head of `main`).