### PR TITLE
Unpin `time` dependency and remove failing test case

### DIFF
--- a/light-client-verifier/Cargo.toml
+++ b/light-client-verifier/Cargo.toml
@@ -30,7 +30,7 @@ tendermint = { version = "0.23.6", path = "../tendermint", default-features = fa
 
 derive_more = { version = "0.99.5", default-features = false, features = ["display"] }
 serde = { version = "1.0.106", default-features = false }
-time = { version = "0.3.5", default-features = false }
+time = { version = "0.3", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 
 [dev-dependencies]

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -48,7 +48,7 @@ signature = { version = "1.2", default-features = false }
 subtle = { version = "2", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
 tendermint-proto = { version = "0.23.6", default-features = false, path = "../proto" }
-time = { version = "=0.3.11", default-features = false, features = ["macros", "parsing"] }
+time = { version = "0.3", default-features = false, features = ["macros", "parsing"] }
 zeroize = { version = "1.1", default-features = false, features = ["zeroize_derive", "alloc"] }
 flex-error = { version = "0.4.4", default-features = false }
 k256 = { version = "0.10", optional = true, default-features = false, features = ["ecdsa", "sha256"] }

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -233,7 +233,6 @@ mod tests {
         let dts = vec![
             datetime!(0000-12-31 23:59:59.999999999 UTC),
             datetime!(0001-01-01 00:00:00.999999999 +00:00:01),
-            datetime!(9999-12-31 23:59:59 -00:00:01),
             Date::from_calendar_date(-1, October, 9)
                 .unwrap()
                 .midnight()


### PR DESCRIPTION
Relates to https://github.com/anoma/namada/issues/825

Based partially on https://github.com/informalsystems/tendermint-rs/pull/1199 which also removes this test case, which started failing on upgrading to `time = 0.3.13` (so was previously downgraded - https://github.com/heliaxdev/tendermint-rs/pull/10/commits/7c6a483218c8e897189c6af17939e154878597a5)